### PR TITLE
fix: Improve GitHub CLI installation and use PowerShell for workflow command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-automation",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-automation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "expectrl",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-automation"
-version = "0.1.0"
+version = "0.1.1"
 description = "To automate the workflow"
 authors = ["Dewans Nehra"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "workflow-automation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.workflow-automation.app",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
- Improve GitHub CLI installation now passing `--accept-source-agreements` flag to handle the error for new winget users.
- Using PowerShell for workflow command instead  of `sh`